### PR TITLE
Fix issue with tw-pddl data

### DIFF
--- a/alfworld/agents/agent/text_dagger_agent.py
+++ b/alfworld/agents/agent/text_dagger_agent.py
@@ -252,7 +252,6 @@ class TextDAggerAgent(BaseAgent):
                     break
             res = [self.tokenizer.decode(item) for item in input_target_list]
             res = [item.replace("[CLS]", "").replace("[SEP]", "").strip() for item in res]
-            res = [item.replace(" in / on ", " in/on " ) for item in res]
             return res, current_dynamics
 
     def command_generation_beam_search_generation(self, observation_strings, task_desc_strings, previous_dynamics):
@@ -351,7 +350,6 @@ class TextDAggerAgent(BaseAgent):
                     utte_string = self.tokenizer.decode(utte)
                     utterances.append(utte_string)
                 utterances = [item.replace("[CLS]", "").replace("[SEP]", "").strip() for item in utterances]
-                utterances = [item.replace(" in / on ", " in/on " ) for item in utterances]
                 res.append(utterances)
             return res, current_dynamics
 

--- a/alfworld/agents/agent/text_dqn_agent.py
+++ b/alfworld/agents/agent/text_dqn_agent.py
@@ -265,7 +265,6 @@ class TextDQNAgent(BaseAgent):
                     utterances.append(utte_string)
 
                 utterances = [item.replace("[CLS]", "").replace("[SEP]", "").strip() for item in utterances]
-                utterances = [item.replace(" in / on ", " in/on " ) for item in utterances]
                 chosen_actions.append(utterances)
             return chosen_actions, current_dynamics, obs_mask, aggregated_obs_representation
 
@@ -306,7 +305,6 @@ class TextDQNAgent(BaseAgent):
                     break
             chosen_actions = [self.tokenizer.decode(item) for item in input_target_list]
             chosen_actions = [item.replace("[CLS]", "").replace("[SEP]", "").strip() for item in chosen_actions]
-            chosen_actions = [item.replace(" in / on ", " in/on " ) for item in chosen_actions]
             chosen_indices = [item[1:] for item in input_target_list]
             for i in range(len(chosen_indices)):
                 if chosen_indices[i][-1] == self.word2id["[SEP]"]:
@@ -404,7 +402,6 @@ class TextDQNAgent(BaseAgent):
                     indicies.append(utte)
 
                 utterances = [item.replace("[CLS]", "").replace("[SEP]", "").strip() for item in utterances]
-                utterances = [item.replace(" in / on ", " in/on " ) for item in utterances]
                 indicies = [item[1:] for item in indicies]
                 for i in range(len(indicies)):
                     if indicies[i][-1] == self.word2id["[SEP]"]:

--- a/alfworld/agents/expert/handcoded_expert.py
+++ b/alfworld/agents/expert/handcoded_expert.py
@@ -236,7 +236,7 @@ class BasePolicy(object):
                 # if holding something irrelavant, then discard it from where it was pickedup
                 if len(self.inventory) > 0 and not self.is_agent_holding_right_object:
                     if self.curr_recep == self.got_inventory_from_recep:
-                        return "put {} in/on {}".format(self.inventory[0], self.got_inventory_from_recep)
+                        return "move {} to {}".format(self.inventory[0], self.got_inventory_from_recep)
                     else:
                         return "go to {}".format(self.got_inventory_from_recep)
 
@@ -276,7 +276,7 @@ class BasePolicy(object):
                 return "open {}".format(self.curr_recep)
             else:
                 obj = self.inventory[0]
-                return "put {} in/on {}".format(obj, self.curr_recep)
+                return "move {} to {}".format(obj, self.curr_recep)
 
         # OPEN
         if sub_action == 'open':
@@ -321,7 +321,7 @@ class BasePolicy(object):
         # if holding something irrelavant, then discard it from where it was pickedup
         if len(self.inventory) > 0 and not self.is_agent_holding_right_object:
             if self.curr_recep == self.got_inventory_from_recep:
-                return "put {} in/on {}".format(self.inventory[0], self.got_inventory_from_recep)
+                return "move {} to {}".format(self.inventory[0], self.got_inventory_from_recep)
             else:
                 return "go to {}".format(self.got_inventory_from_recep)
 

--- a/alfworld/agents/expert/handcoded_expert_tw.py
+++ b/alfworld/agents/expert/handcoded_expert_tw.py
@@ -14,7 +14,7 @@ class PickAndPlaceSimpleTWPolicy(PickAndPlaceSimplePolicy):
         obs_at_curr_recep = self.obs_at_recep[self.curr_recep] if self.curr_recep in self.obs_at_recep else ""
         is_obj_in_obs = "you see" in obs_at_curr_recep and " {} ".format(obj) in obs_at_curr_recep
         at_right_recep = parent in self.curr_recep
-        can_put_object = "put {} in/on {}".format(obj, parent) in admissible_commands_wo_num_ids
+        can_put_object = "move {} to {}".format(obj, parent) in admissible_commands_wo_num_ids
         can_take_object = any("take {}".format(obj) in ac for ac in admissible_commands_wo_num_ids)
         return at_right_recep, can_put_object, can_take_object, is_obj_in_obs
 
@@ -35,7 +35,7 @@ class PickTwoObjAndPlaceTWPolicy(PickTwoObjAndPlacePolicy):
         obs_at_curr_recep = self.obs_at_recep[self.curr_recep] if self.curr_recep in self.obs_at_recep else ""
         is_obj_in_obs = "you see" in obs_at_curr_recep and " {} ".format(obj) in obs_at_curr_recep
         at_right_recep = parent in self.curr_recep
-        can_put_object = "put {} in/on {}".format(obj, parent) in admissible_commands_wo_num_ids
+        can_put_object = "move {} to {}".format(obj, parent) in admissible_commands_wo_num_ids
         can_take_object = any("take {}".format(obj) in ac for ac in admissible_commands_wo_num_ids)
         return at_right_recep, can_put_object, can_take_object, is_obj_in_obs, is_one_object_already_inside_receptacle, trying_to_take_the_same_object
 
@@ -68,7 +68,7 @@ class PickHeatThenPlaceInRecepTWPolicy(PickHeatThenPlaceInRecepPolicy):
         obs_at_curr_recep = self.obs_at_recep[self.curr_recep] if self.curr_recep in self.obs_at_recep else ""
         is_obj_in_obs = "you see" in obs_at_curr_recep and " {} ".format(obj) in obs_at_curr_recep
         at_right_recep = parent in self.curr_recep
-        can_put_object = "put {} in/on {}".format(obj, parent) in admissible_commands_wo_num_ids
+        can_put_object = "move {} to {}".format(obj, parent) in admissible_commands_wo_num_ids
         can_take_object = any("take {}".format(obj) in ac for ac in admissible_commands_wo_num_ids)
         can_heat_object = "heat {} with {}".format(obj, "microwave") in admissible_commands_wo_num_ids
         return at_right_recep, can_heat_object, can_put_object, can_take_object, is_obj_in_obs, is_the_object_agent_holding_hot
@@ -87,7 +87,7 @@ class PickCoolThenPlaceInRecepTWPolicy(PickCoolThenPlaceInRecepPolicy):
         obs_at_curr_recep = self.obs_at_recep[self.curr_recep] if self.curr_recep in self.obs_at_recep else ""
         is_obj_in_obs = "you see" in obs_at_curr_recep and " {} ".format(obj) in obs_at_curr_recep
         at_right_recep = parent in self.curr_recep
-        can_put_object = "put {} in/on {}".format(obj, parent) in admissible_commands_wo_num_ids
+        can_put_object = "move {} to {}".format(obj, parent) in admissible_commands_wo_num_ids
         can_cool_object = "cool {} with {}".format(obj, "fridge") in admissible_commands_wo_num_ids
         can_take_object = any("take {}".format(obj) in ac for ac in admissible_commands_wo_num_ids)
         return at_right_recep, can_cool_object, can_put_object, can_take_object, is_obj_in_obs, is_the_object_agent_holding_cool
@@ -106,7 +106,7 @@ class PickCleanThenPlaceInRecepTWPolicy(PickCleanThenPlaceInRecepPolicy):
         obs_at_curr_recep = self.obs_at_recep[self.curr_recep] if self.curr_recep in self.obs_at_recep else ""
         is_obj_in_obs = "you see" in obs_at_curr_recep and " {} ".format(obj) in obs_at_curr_recep
         at_right_recep = parent in self.curr_recep
-        can_put_object = "put {} in/on {}".format(obj, parent) in admissible_commands_wo_num_ids
+        can_put_object = "move {} to {}".format(obj, parent) in admissible_commands_wo_num_ids
         can_clean_object = "clean {} with {}".format(obj, "sinkbasin") in admissible_commands_wo_num_ids
         can_take_object = any("take {}".format(obj) in ac for ac in admissible_commands_wo_num_ids)
         return at_right_recep, can_clean_object, can_put_object, can_take_object, is_obj_in_obs, is_the_object_agent_holding_isclean

--- a/alfworld/agents/utils/misc.py
+++ b/alfworld/agents/utils/misc.py
@@ -154,7 +154,7 @@ def extract_admissible_commands_with_heuristics(intro, frame_desc, feedback,
         "open {recep}",
         "close {recep}",
         "take {obj} from {recep}",
-        "put {obj} in/on {recep}",
+        "move {obj} to {recep}",
         "use {lamp}",
         "heat {obj} with {microwave}",
         "cool {obj} with {fridge}",
@@ -162,6 +162,7 @@ def extract_admissible_commands_with_heuristics(intro, frame_desc, feedback,
         "slice {obj} with {knife}",
         "inventory",
         "look",
+        "help",
         "examine {obj}",
         "examine {recep}"
     ]
@@ -182,7 +183,7 @@ def extract_admissible_commands_with_heuristics(intro, frame_desc, feedback,
                 for obj in objects:
                     if 'desklamp' not in obj and 'floorlamp' not in obj:
                         admissible_commands.append(t.format(recep=at_recep, obj=obj))
-        elif 'put {obj} in/on {recep}' in t:
+        elif 'move {obj} to {recep}' in t:
             if in_inv and at_recep:
                 admissible_commands.append(t.format(recep=at_recep, obj=in_inv))
         elif '{obj}' in t and '{microwave}' in t:
@@ -246,7 +247,7 @@ def extract_admissible_commands(intro, frame_desc):
         "open {recep}",
         "close {recep}",
         "take {obj} from {recep}",
-        "put {obj} in/on {recep}",
+        "move {obj} to {recep}",
         "use {lamp}",
         "heat {obj} with {microwave}",
         "cool {obj} with {fridge}",
@@ -254,6 +255,7 @@ def extract_admissible_commands(intro, frame_desc):
         "slice {obj} with {knife}",
         "inventory",
         "look",
+        "help",
         "examine {obj}",
         "examine {recep}"
     ]

--- a/alfworld/data/alfred.pddl
+++ b/alfworld/data/alfred.pddl
@@ -495,4 +495,14 @@
  )
 
 
+(:action help
+    :parameters (?a - agent)
+    :precondition
+        ()
+    :effect
+        (and
+            (checked ?a)
+        )
+)
+
 )

--- a/alfworld/data/alfred.twl2
+++ b/alfworld/data/alfred.twl2
@@ -20,7 +20,7 @@ grammar :: """
 
         "GotoLocation.feedback": [
             {
-                "rhs": "You arrive at {lend.name}. #examineReceptacle.feedback#"
+                "rhs": "You arrive at {r.name}. #examineReceptacle.feedback#"
             }
         ],
 
@@ -62,7 +62,7 @@ grammar :: """
 
         "PutObject.feedback": [
             {
-                "rhs": "You put the {o.name} in/on the {r.name}."
+                "rhs": "You move the {o.name} to the {r.name}."
             }
         ],
 
@@ -208,7 +208,7 @@ action PickupFullReceptacleObject {
 }
 
 action PutObject {
-    template :: "put {o} in/on {r}";
+    template :: "move {o} to {r}";
     feedback :: "#PutObject.feedback#";
 }
 
@@ -218,7 +218,7 @@ action PutObjectInReceptacleObject {
 }
 
 action PutEmptyReceptacleObjectinReceptacle {
-    template :: "put {o} in/on {r}";
+    template :: "move {o} to {r}";
     feedback :: "#PutEmptyReceptacleObjectinReceptacle.feedback#";
 }
 
@@ -415,6 +415,21 @@ action look {
             "list_last_separator": [
                 {
                     "rhs": ", and "
+                }
+            ]
+        }
+    """;
+}
+
+action help {
+    template :: "help";
+    feedback :: "#help.feedback#";
+
+    grammar :: """
+        {
+            "help.feedback": [
+                {
+                    "rhs": "\nAvailable commands:\n  look:                             look around your current location\n  inventory:                        check your current inventory\n  go to (receptacle):               move to a receptacle\n  open (receptacle):                open a receptacle\n  close (receptacle):               close a receptacle\n  take (object) from (receptacle):  take an object from a receptacle\n  move (object) to (receptacle):  place an object in or on a receptacle\n  examine (something):              examine a receptacle or an object\n  use (object):                     use an object\n  heat (object) with (receptacle):  heat an object using a receptacle\n  clean (object) with (receptacle): clean an object using a receptacle\n  cool (object) with (receptacle):  cool an object using a receptacle\n  slice (object) with (object):     slice an object using a sharp object\n"
                 }
             ]
         }

--- a/alfworld/info.py
+++ b/alfworld/info.py
@@ -1,4 +1,4 @@
-__version__ = '0.4.0rc2'
+__version__ = '0.4.0'
 
 import os
 from os.path import join as pjoin

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -45,7 +45,7 @@ You heat the potato 1 using the microwave 1.
 You arrive at loc 8. On the sinkbasin 1, you see a knife 3, a egg 2,
 and a dishsponge 3.
 
-> put potato 1 in/on sinkbasin 1
+> move potato 1 to sinkbasin 1
 You won!
 ```
 

--- a/scripts/alfworld-download
+++ b/scripts/alfworld-download
@@ -17,7 +17,7 @@ from alfworld.info import ALFRED_PDDL_PATH, ALFRED_TWL2_PATH
 
 JSON_FILES_URL = "https://github.com/alfworld/alfworld/releases/download/0.2.2/json_2.1.1_json.zip"
 PDDL_FILES_URL = "https://github.com/alfworld/alfworld/releases/download/0.2.2/json_2.1.1_pddl.zip"
-TW_PDDL_FILES_URL = "https://github.com/alfworld/alfworld/releases/download/0.2.2/json_2.1.1_tw-pddl.zip"
+TW_PDDL_FILES_URL = "https://github.com/alfworld/alfworld/releases/download/0.4.0/json_2.1.2_tw-pddl.zip"
 MRCNN_URL = "https://github.com/alfworld/alfworld/releases/download/0.2.2/mrcnn_alfred_objects_sep13_004.pth"
 CHECKPOINTS_URL = "https://github.com/alfworld/alfworld/releases/download/0.2.2/pretrained_checkpoints.zip"
 SEQ2SEQ_DATA_URL = "https://github.com/alfworld/alfworld/releases/download/0.2.2/seq2seq_data.zip"

--- a/scripts/alfworld-play-tw
+++ b/scripts/alfworld-play-tw
@@ -34,7 +34,7 @@ def main(args):
     # dump game file
     gamedata = dict(**GAME_LOGIC, pddl_problem=open(pddl_file).read())
     gamefile = os.path.join(os.path.dirname(pddl_file), 'game.tw-pddl')
-    json.dump(gamedata, open(gamefile, "w"))
+    #json.dump(gamedata, open(gamefile, "w"))
 
 
     expert = AlfredExpert(expert_type=AlfredExpertType.PLANNER)
@@ -93,7 +93,7 @@ if __name__ == "__main__":
 
         if len(problems) == 0:
             raise ValueError(f"Can't find problem files in {ALFWORLD_DATA}. Did you run alfworld-data?")
-        
+
         args.problem = os.path.dirname(random.choice(problems))
 
     if "movable_recep" in args.problem:

--- a/scripts/patch_tw-pddl.py
+++ b/scripts/patch_tw-pddl.py
@@ -1,0 +1,71 @@
+# This script is to patch the 2.1.1 game.tw-pddl files to bring up to 2.1.2.
+# This script will add a new "help" action and separate the "PutObject" action
+#  into two separate actions: PutObjectInContainer and PutObjectOnSupporter.
+# This script will also add the corresponding grammar for the new actions.
+# This script also patch the grammar to fix a typo in the go-to feedback.
+# The script will create a backup of the original file before patching.
+
+import os
+import json
+from glob import glob
+from os.path import join as pjoin
+from tqdm import tqdm
+
+from alfworld.info import ALFWORLD_DATA
+import os
+import json
+
+import tqdm
+
+
+HELP_ACTION_PDDL = """\
+(:action help
+    :parameters (?a - agent)
+    :precondition
+        ()
+    :effect
+        (and
+            (checked ?a)
+        )
+)
+"""
+
+HELP_GRAMMAR = """\
+
+action help {
+    template :: "help";
+    feedback :: "\nAvailable commands:\n  look:                             look around your current location\n  inventory:                        check your current inventory\n  go to (receptacle):               move to a receptacle\n  open (receptacle):                open a receptacle\n  close (receptacle):               close a receptacle\n  take (object) from (receptacle):  take an object from a receptacle\n  move (object) to (receptacle):  place an object in or on a receptacle\n  examine (something):              examine a receptacle or an object\n  use (object):                     use an object\n  heat (object) with (receptacle):  heat an object using a receptacle\n  clean (object) with (receptacle): clean an object using a receptacle\n  cool (object) with (receptacle):  cool an object using a receptacle\n  slice (object) with (object):     slice an object using a sharp object\n";
+}
+"""
+
+def patch_twpddl(filename):
+    with open(filename, "r") as f:
+        data = json.load(f)
+
+    # Make backup if doesn't exist
+    if not os.path.exists(filename + ".bak"):
+        with open(filename + ".bak", "w") as f:
+            json.dump(data, f)
+
+    # Always start from backup.
+    with open(filename + ".bak") as f:
+        data = json.load(f)
+
+    # Patch domain pddl.
+    before, after = data["pddl_domain"].rsplit(")", 1)
+    data["pddl_domain"] = f"{before}{HELP_ACTION_PDDL}){after}"
+
+    # Patch grammar.
+    data["grammar"] = data["grammar"].replace("You arrive at {lend.name}.", "You arrive at {r.name}.")
+    data["grammar"] = data["grammar"].replace("put {o} in/on {r}", "move {o} to {r}")
+    data["grammar"] = data["grammar"].replace("You put the {o.name} in/on the {r.name}.", "You move the {o.name} to the {r.name}.")
+    data["grammar"] += HELP_GRAMMAR
+
+    with open(filename, "w") as f:
+        json.dump(data, f)
+
+
+filenames = glob(pjoin(ALFWORLD_DATA, "json_2.1.1/**/**/**/*.tw-pddl"))
+
+for filename in tqdm(filenames):
+   patch_twpddl(filename)


### PR DESCRIPTION
This pull request focuses on updating the terminology used for the command "put" and adding a new "help" command. The most important changes include replacing the "put in/on" command with "move to" across various code and data files.

While at it, this PR also fixes #52 where `go to` feedback messages now display the proper location's name.

This PR also include a script `scripts/patch_tw-pddl.py` to update any old `game.tw-pddl` files to use the newer syntax.