### PR TITLE
Support "move.." action in AlfredThorEnv. Remove Sink and Bathtub from receptacles.

### DIFF
--- a/alfworld/agents/controller/base.py
+++ b/alfworld/agents/controller/base.py
@@ -15,7 +15,7 @@ class BaseAgent(object):
     '''
 
     # constants
-    RECEPTACLES = set(constants.RECEPTACLES) | {'Sink', 'Bathtub'}
+    RECEPTACLES = set(constants.RECEPTACLES)  # | {'Sink', 'Bathtub'}  # Thor doesn't consider these as receptacles.
     OBJECTS = (set(constants.OBJECTS_WSLICED) - set(RECEPTACLES)) | set(constants.MOVABLE_RECEPTACLES)
     OBJECTS -= {'Blinds', 'Boots', 'Cart', 'Chair', 'Curtains', 'Footstool', 'Mirror', 'LightSwtich', 'Painting', 'Poster', 'ShowerGlass', 'Window'}
     STATIC_RECEPTACLES = set(RECEPTACLES) - set(constants.MOVABLE_RECEPTACLES)
@@ -229,3 +229,6 @@ class BaseAgent(object):
     def step(self, action_str):
         self.feedback = "Nothing happens."
         return self.feedback
+
+
+

--- a/alfworld/agents/controller/base.py
+++ b/alfworld/agents/controller/base.py
@@ -189,6 +189,9 @@ class BaseAgent(object):
         elif "put " in action_str:
             obj, rel, tar = get_triplet(action_str, "put ")
             return {'action': self.Action.PUT, 'obj': obj, 'rel': rel, 'tar': tar}
+        elif "move " in action_str:
+            obj, rel, tar = get_triplet(action_str, "move ")
+            return {'action': self.Action.PUT, 'obj': obj, 'rel': rel, 'tar': tar}
         elif "open " in action_str:
             tar = action_str.replace("open ", "")
             return {'action': self.Action.OPEN, 'tar': tar}
@@ -226,6 +229,3 @@ class BaseAgent(object):
     def step(self, action_str):
         self.feedback = "Nothing happens."
         return self.feedback
-
-
-


### PR DESCRIPTION
Fixes #119 

This pull request makes two key updates to the `BaseAgent` class in the `alfworld/agents/controller/base.py` file: refining the definition of receptacles and adding support for a new "move" action in the action parsing logic.

### Changes to receptacle definitions:
* Updated the `RECEPTACLES` constant to exclude `Sink` and `Bathtub`, as these are not considered receptacles by Thor. The change comments out their inclusion for clarity.

### Enhancements to action parsing:
* Added support for the "move" action in the `action_str` parsing logic. This allows the agent to interpret and handle "move" commands by mapping them to the `PUT` action type with appropriate object, relation, and target parameters.