### PR TITLE
Exprt should only suggest to toggle lamp if it appears in the observation

### DIFF
--- a/alfworld/agents/expert/handcoded_expert_tw.py
+++ b/alfworld/agents/expert/handcoded_expert_tw.py
@@ -50,9 +50,10 @@ class LookAtObjInLightTWPolicy(LookAtObjInLightPolicy):
         self.is_agent_holding_right_object = "holds agent {}".format(obj) in facts_wo_num_ids
         obs_at_curr_recep = self.obs_at_recep[self.curr_recep] if self.curr_recep in self.obs_at_recep else ""
         is_obj_in_obs = "you see" in obs_at_curr_recep and " {} ".format(obj) in obs_at_curr_recep
+        is_lamp_in_obs = "you see" in obs_at_curr_recep and " {} ".format(toggle) in obs_at_curr_recep
         can_toggle_lamp = "use {}".format(toggle) in admissible_commands_wo_num_ids
         can_take_object = any("take {}".format(obj) in ac for ac in admissible_commands_wo_num_ids)
-        return can_take_object, can_toggle_lamp, is_obj_in_obs
+        return can_take_object, can_toggle_lamp and is_lamp_in_obs, is_obj_in_obs,
 
 
 class PickHeatThenPlaceInRecepTWPolicy(PickHeatThenPlaceInRecepPolicy):


### PR DESCRIPTION
Fixes #121 

This pull request modifies the logic in the `get_predicates` method of the `handcoded_expert_tw.py` file to improve how predicates related to object and lamp interactions are determined. The key change ensures that toggling a lamp is only considered possible if the lamp is observed in the current scene.

### Logic adjustment for predicate determination:
* [`alfworld/agents/expert/handcoded_expert_tw.py`](diffhunk://#diff-622d50dddfc6539f0f19b9282b92fbfac432e9e93490719c4d399d74284f351fR53-R56): Added a new condition, `is_lamp_in_obs`, to check if the lamp (specified by `toggle`) is visible in the current observation. Updated the return statement to include this condition in conjunction with `can_toggle_lamp`. This ensures that toggling the lamp is only allowed when it is visible in the scene.