### PR TITLE
When selecting a game at random, make sure it has the .tw-pddl file.

### DIFF
--- a/scripts/alfworld-play-tw
+++ b/scripts/alfworld-play-tw
@@ -3,6 +3,7 @@
 import os
 import json
 import glob
+from pathlib import Path
 import random
 import argparse
 from os.path import join as pjoin
@@ -61,8 +62,8 @@ def main(args):
         print(obs)
         cmd = agent.act(infos, 0, False)
 
-        if cmd == "ipdb":
-            from ipdb import set_trace; set_trace()
+        if cmd == "debug":
+            breakpoint()
             continue
 
         obs, score, done, infos = env.step(cmd)
@@ -76,7 +77,7 @@ if __name__ == "__main__":
     description = "Play the abstract text version of an ALFRED environment."
     parser = argparse.ArgumentParser(description=description)
     parser.add_argument("problem", nargs="?", default=None,
-                        help="Path to a folder containing PDDL and traj_data files."
+                        help="Path to a folder containing a .tw-pddl file."
                              f"Default: pick one at random found in {ALFWORLD_DATA}")
     parser.add_argument("--domain",
                         default=pjoin(ALFWORLD_DATA, "logic", "alfred.pddl"),
@@ -91,10 +92,16 @@ if __name__ == "__main__":
     args = parser.parse_args()
 
     if args.problem is None:
-        problems = glob.glob(pjoin(ALFWORLD_DATA, "**", "initial_state.pddl"), recursive=True)
+        problems = glob.glob(pjoin(ALFWORLD_DATA, "**", "game.tw-pddl"), recursive=True)
 
         # Remove problem which contains movable receptacles.
         problems = [p for p in problems if "movable_recep" not in p]
+
+        # List all number of problems found in each sub directory (train, valid_train, valid_seen, valid_unseen).
+        print(f"Found {len(problems)} problems in {ALFWORLD_DATA}:")
+        for split in ["train", "valid_train", "valid_seen", "valid_unseen"]:
+            split_problems = [p for p in problems if split in Path(p).parts]
+            print(f"  {split}: {len(split_problems)} problems")
 
         if len(problems) == 0:
             raise ValueError(f"Can't find problem files in {ALFWORLD_DATA}. Did you run alfworld-data?")
@@ -103,5 +110,20 @@ if __name__ == "__main__":
 
     if "movable_recep" in args.problem:
         raise ValueError("This problem contains movable receptacles, which is not supported by ALFWorld.")
+
+    # Make sure the domain and grammar files exist.
+    if not os.path.isfile(args.domain):
+        raise ValueError(f"Domain file not found: {args.domain}")
+    if not os.path.isfile(args.grammar):
+        raise ValueError(f"Grammar file not found: {args.grammar}")
+
+    # Make sure the tw-pddl file exists in the problem folder.
+    tw_pddl_file = os.path.join(args.problem, 'game.tw-pddl')
+    if not os.path.isfile(tw_pddl_file):
+        msg = (
+            f"tw-pddl file not found in {args.problem}. Did you run alfworld-data?"
+            " Note that not all problems in ALFWorld have a tw-pddl file, but only those that are compatible with the text-based environment (i.e. without movable receptacles)."
+        )
+        raise ValueError(msg)
 
     main(args)


### PR DESCRIPTION
This pull request updates the `scripts/alfworld-play-tw` script to improve file validation, enhance user feedback, and clarify the handling of ALFWorld problem files. The changes ensure that required files are present before execution and provide more informative output about available problems.

File validation improvements:

* Added checks to ensure that the domain and grammar files specified by the user exist before running the script, raising clear errors if not found.
* Added validation to confirm the presence of the `game.tw-pddl` file in the selected problem folder, with an explanatory error message if missing.

User feedback enhancements:

* When selecting a random problem, the script now prints the number of problems found in each split (train, valid_train, valid_seen, valid_unseen), giving users better visibility into available data.

Clarification and usability improvements:

* Updated the command-line argument help text to clarify that the `problem` argument expects a folder containing a `.tw-pddl` file, not just generic PDDL/traj_data files.
* Changed the debug command from `"ipdb"` to `"debug"` and replaced the legacy `ipdb` invocation with Python's built-in `breakpoint()` for easier debugging.

General code quality:

* Imported `Path` from `pathlib` to facilitate improved path handling in the script.

Fixes #129 